### PR TITLE
Fix dockerfile build error on Win10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,13 @@ WORKDIR /workspace/app
 
 COPY . /workspace/app
 #RUN --mount=type=cache,target=/root/.gradle ./gradlew clean build
-RUN ./gradlew clean build
+RUN apt-get update && \
+    apt-get install dos2unix && \
+    apt-get clean
+
+RUN chmod +x ./gradlew
+RUN dos2unix ./gradlew 
+RUN ./gradlew clean build 
 
 RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*.jar)
 


### PR DESCRIPTION
Fix https://github.com/kingtigerwin/wholesale/issues/1#issue-1111199008

![Snipaste_2022-01-22_02-03-10](https://user-images.githubusercontent.com/68600416/150622170-d2afa56d-2eb7-474d-9414-9f744434572f.png)

This error only occurs on Windows system Docker, AWS CodeBuild is on Linux system Docker

Reference
https://stackoverflow.com/questions/18172405/getting-error-usr-bin-env-sh-no-such-file-or-directory-when-running-command-p